### PR TITLE
fix: skip client-side fuse re-filtering for async search results

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,13 +8,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
           version: 8
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: "pnpm"
 
       - run: pnpm install --no-frozen-lockfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-       - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
           version: 8

--- a/src/composables/useCmdBarState.ts
+++ b/src/composables/useCmdBarState.ts
@@ -190,14 +190,16 @@ export function useCmdBarState() {
     const asyncGroups = relevantGroups.filter((group) => !!group.search)
     const asyncResults = await asyncSearch(query, asyncGroups)
     const syncGroups = relevantGroups.filter((group) => !group.search) as Group[]
-    let commandsToSearch = syncGroups.flatMap(
+    const syncCommands = syncGroups.flatMap(
       (group) =>
         (group.commands ?? []).map((command) => ({ ...command, group: group.key })) as Command[]
     )
+    // Only fuzzy-search sync commands — async groups already performed server-side search
+    const fusedResults = fuzzySearch(query, syncCommands)
     if (Array.isArray(asyncResults) && asyncResults.length > 0) {
-      commandsToSearch = commandsToSearch.concat(asyncResults)
+      return fusedResults.concat(asyncResults)
     }
-    return fuzzySearch(query, commandsToSearch)
+    return fusedResults
   }
 
   function fuzzySearch(query: string, commands: Command[]) {


### PR DESCRIPTION
## Summary

- **Bug**: Groups with an async `search()` function already perform server-side filtering, but their results were being re-filtered through Fuse.js (which defaults to `keys: ['label']`). This caused valid results to be dropped when the search query matched non-label fields (e.g. email, booking number, invoice recipient).
- **Fix**: Only run `fuzzySearch()` on sync commands (local/static groups). Async results are concatenated directly into the final result set without client-side re-filtering.

## The Problem

In `useCmdBarState.ts`, the `search()` function:

1. Splits groups into **async** (has `search()` fn) and **sync** (static commands)
2. Calls `group.search!(query)` for async groups → gets server-filtered results ✅
3. Merges async + sync results together
4. Passes **everything** through `fuzzySearch()` → Fuse.js with `keys: ['label']` ❌

Step 4 is wrong for async results. Example: searching `p.enis@gmail.com` for customers — the API correctly returns "Peter Enis", but Fuse.js tries to match `p.enis@gmail.com` against the label "Peter Enis" and drops it.

## The Fix

```diff
- let commandsToSearch = syncGroups.flatMap(...)
- if (Array.isArray(asyncResults) && asyncResults.length > 0) {
-   commandsToSearch = commandsToSearch.concat(asyncResults)
- }
- return fuzzySearch(query, commandsToSearch)
+ const syncCommands = syncGroups.flatMap(...)
+ const fusedResults = fuzzySearch(query, syncCommands)
+ if (Array.isArray(asyncResults) && asyncResults.length > 0) {
+   return fusedResults.concat(asyncResults)
+ }
+ return fusedResults
```

Sync groups still get full Fuse.js fuzzy matching. Async groups trust their server-side search.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command/search behavior so synchronous fuzzy results are kept separate from asynchronous results, yielding clearer and more consistent search results.
* **Chores**
  * Updated CI build environment to a newer Node.js runtime (22.x).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->